### PR TITLE
added zip_code in lib_resume_builder_AIHawk

### DIFF
--- a/lib_resume_builder_AIHawk/resume.py
+++ b/lib_resume_builder_AIHawk/resume.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional, Union
 import yaml
-from pydantic import BaseModel, EmailStr, HttpUrl
+from pydantic import BaseModel, EmailStr, HttpUrl, Field
 
 
 
@@ -12,6 +12,7 @@ class PersonalInformation(BaseModel):
     country: Optional[str]
     city: Optional[str]
     address: Optional[str]
+    zip_code: Optional[str] = Field(None, regex="^[0-9]{5,10}$")
     phone_prefix: Optional[str]
     phone: Optional[str]
     email: Optional[EmailStr]

--- a/lib_resume_builder_AIHawk/unit-test/yaml_example/plain_text_resume.yaml
+++ b/lib_resume_builder_AIHawk/unit-test/yaml_example/plain_text_resume.yaml
@@ -5,6 +5,7 @@ personal_information:
   country: USA
   city: New York
   address: 123 Main St
+  zip_code: "520123"
   phone_prefix: "+1"
   phone: "123-456-7890"
   email: john.doe@example.com

--- a/plain_text_resume.yaml
+++ b/plain_text_resume.yaml
@@ -5,6 +5,7 @@ personal_information:
   country: "Ireland"
   city: "Dublin"
   address: "Dublin 1"
+  zip_code: "520123"
   phone_prefix: "+353"
   phone: "892338335"
   email: "fedembare@gmail.com"


### PR DESCRIPTION
Hey @feder-cr,

I’ve updated the following files to include the zip code in the resume:

-     lib_resume_builder_AIHawk/resume.py
-     lib_resume_builder_AIHawk/unit-test/yaml_example/plain_text_resume.yaml
-     plain_text_resume.yaml


Initially, I thought updating the resume_schema would be enough. I’ve also run tests, but I’m unsure if the changes to lib_resume_builder_AIHawk were necessary.