### PR TITLE
Unwrap `job_responsibilities` items

### DIFF
--- a/lib_resume_builder_AIHawk/resume.py
+++ b/lib_resume_builder_AIHawk/resume.py
@@ -36,7 +36,7 @@ class ExperienceDetails(BaseModel):
     employment_period: Optional[str]
     location: Optional[str]
     industry: Optional[str]
-    key_responsibilities: Optional[List[Dict[str, str]]] = None
+    key_responsibilities: Optional[List[str]] = None
     skills_acquired: Optional[List[str]] = None
 
 
@@ -162,7 +162,7 @@ class Resume(BaseModel):
         for exp in data:
             try:
                 key_responsibilities = [
-                    Responsibility(description=list(resp.values())[0])
+                    Responsibility(description=resp)
                     for resp in exp.get('key_responsibilities', [])
                 ]
                 skills_acquired = [str(skill) for skill in exp.get('skills_acquired', [])]

--- a/lib_resume_builder_AIHawk/unit-test/yaml_example/plain_text_resume.yaml
+++ b/lib_resume_builder_AIHawk/unit-test/yaml_example/plain_text_resume.yaml
@@ -25,7 +25,7 @@ experience_details:
     location: New York, USA
     industry: IT
     key_responsibilities:
-      - task: Developed web applications
+      - Developed web applications
     skills_acquired:
       - Python
       - JavaScript

--- a/plain_text_resume.yaml
+++ b/plain_text_resume.yaml
@@ -34,9 +34,9 @@ experience_details:
     location: "Italy"
     industry: "Blockchain Technology"
     key_responsibilities:
-      - responsibility_1:  "Co-founded and led a startup specializing in app and software development with a focus on blockchain technology"
-      - responsibility_2:  "Provided blockchain consultations for 10+ companies, enhancing their software capabilities with secure, decentralized solutions"
-      - responsibility_3: "Developed blockchain applications, integrated cutting-edge technology to meet client needs and drive industry innovation"
+      -  "Co-founded and led a startup specializing in app and software development with a focus on blockchain technology"
+      -  "Provided blockchain consultations for 10+ companies, enhancing their software capabilities with secure, decentralized solutions"
+      - "Developed blockchain applications, integrated cutting-edge technology to meet client needs and drive industry innovation"
     skills_acquired:
       - "Blockchain development"
       - "Software engineering"
@@ -48,10 +48,10 @@ experience_details:
     location: "Genoa, Italy"
     industry: "IoT Security Research"
     key_responsibilities:
-      - responsibility_1:  "Conducted in-depth research on IoT security, focusing on binary instrumentation and runtime monitoring"
-      - responsibility_2:  "Performed in-depth study of the MQTT protocol and Falco"
-      - responsibility_3:  "Developed multiple software components including MQTT packet analysis library, Falco adapter, and RML monitor in Prolog"
-      - responsibility_4: "Authored thesis 'Binary Instrumentation for Runtime Monitoring of Internet of Things Systems Using Falco'"
+      -  "Conducted in-depth research on IoT security, focusing on binary instrumentation and runtime monitoring"
+      -  "Performed in-depth study of the MQTT protocol and Falco"
+      -  "Developed multiple software components including MQTT packet analysis library, Falco adapter, and RML monitor in Prolog"
+      - "Authored thesis 'Binary Instrumentation for Runtime Monitoring of Internet of Things Systems Using Falco'"
     skills_acquired:
       - "IoT security"
       - "Binary instrumentation"
@@ -64,9 +64,9 @@ experience_details:
     location: "Genoa, Italy"
     industry: "Healthcare IT"
     key_responsibilities:
-      - responsibility_1: "Integrated and enforced robust security protocols"
-      - responsibility_2:  "Developed and maintained a critical software tool for password validation used by over 1,600 employees"
-      - responsibility_3:  "Played an integral role in the hospital's cybersecurity team"
+      - "Integrated and enforced robust security protocols"
+      -  "Developed and maintained a critical software tool for password validation used by over 1,600 employees"
+      -  "Played an integral role in the hospital's cybersecurity team"
     skills_acquired:
       - "Cybersecurity"
       - "Software development"


### PR DESCRIPTION
The placement of each job responsibility string
within a dict is arbitrary, as illustrated by
the current behavior of `_process_experience_details`, 
which makes a comprehension from `job_responsibilities` by
- immediately getting the values of that dict (discarding the one 
   key in the dict)
- ensuring the return of `values()` is returned as a list
- taking the first element of that list
- and instantiating a `Responsibility` with the element 
   as the value for the `description`

The first three steps are in service of unwrapping something that
defined by the application's own schema, and as such, the schema 
can decide that it doesn't need to be wrapped in the first place.