### PR TITLE
feat: Use llm_api_url as OpenAI Base URL if provided

### DIFF
--- a/lib_resume_builder_AIHawk/config.py
+++ b/lib_resume_builder_AIHawk/config.py
@@ -9,6 +9,7 @@ class GlobalConfig:
         self.STYLES_DIRECTORY: Path = None
         self.LOG_OUTPUT_FILE_PATH: Path = None
         self.API_KEY: str = None
+        self.API_BASE_URL: str = None
         self.html_template = """
                             <!DOCTYPE html>
                             <html lang="en">

--- a/lib_resume_builder_AIHawk/gpt_resume.py
+++ b/lib_resume_builder_AIHawk/gpt_resume.py
@@ -162,10 +162,13 @@ class LoggerChatModel:
 
 
 class LLMResumer:
-    def __init__(self, openai_api_key, strings):
+    def __init__(self, openai_api_base, openai_api_key, strings):
         self.llm_cheap = LoggerChatModel(
             ChatOpenAI(
-                model_name="gpt-4o-mini", openai_api_key=openai_api_key, temperature=0.4
+                model_name="gpt-4o-mini",
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
+                temperature=0.4,
             )
         )
         self.strings = strings

--- a/lib_resume_builder_AIHawk/gpt_resume_job_description.py
+++ b/lib_resume_builder_AIHawk/gpt_resume_job_description.py
@@ -178,9 +178,9 @@ class LoggerChatModel:
 
 
 class LLMResumeJobDescription:
-    def __init__(self, openai_api_key, strings):
-        self.llm_cheap = LoggerChatModel(ChatOpenAI(model_name="gpt-4o-mini", openai_api_key=openai_api_key, temperature=0.4))
-        self.llm_embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)
+    def __init__(self, openai_api_base, openai_api_key, strings):
+        self.llm_cheap = LoggerChatModel(ChatOpenAI(model_name="gpt-4o-mini", openai_api_key=openai_api_key, openai_api_base=openai_api_base, temperature=0.4))
+        self.llm_embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key, openai_api_base=openai_api_base)
         self.strings = strings
 
     @staticmethod

--- a/lib_resume_builder_AIHawk/manager_facade.py
+++ b/lib_resume_builder_AIHawk/manager_facade.py
@@ -8,7 +8,7 @@ from lib_resume_builder_AIHawk.utils import HTML_to_PDF
 import webbrowser
 
 class FacadeManager:
-    def __init__(self, api_key, style_manager, resume_generator, resume_object, log_path):
+    def __init__(self, api_key, style_manager, resume_generator, resume_object, log_path, api_base=None):
         # Ottieni il percorso assoluto della directory della libreria
         lib_directory = Path(__file__).resolve().parent
         global_config.STRINGS_MODULE_RESUME_PATH = lib_directory / "resume_prompt/strings_feder-cr.py"
@@ -17,6 +17,7 @@ class FacadeManager:
         global_config.STYLES_DIRECTORY = lib_directory / "resume_style"
         global_config.LOG_OUTPUT_FILE_PATH = log_path
         global_config.API_KEY = api_key
+        global_config.API_BASE_URL = api_base
         self.style_manager = style_manager
         self.style_manager.set_styles_directory(global_config.STYLES_DIRECTORY)
         self.resume_generator = resume_generator

--- a/lib_resume_builder_AIHawk/resume_generator.py
+++ b/lib_resume_builder_AIHawk/resume_generator.py
@@ -22,17 +22,17 @@ class ResumeGenerator:
 
     def create_resume(self, style_path, temp_html_file):
         strings = load_module(global_config.STRINGS_MODULE_RESUME_PATH, global_config.STRINGS_MODULE_NAME)
-        gpt_answerer = LLMResumer(global_config.API_KEY, strings)
+        gpt_answerer = LLMResumer(global_config.API_BASE_URL, global_config.API_KEY, strings)
         self._create_resume(gpt_answerer, style_path, temp_html_file)
 
     def create_resume_job_description_url(self, style_path: str, url_job_description: str, temp_html_path):
         strings = load_module(global_config.STRINGS_MODULE_RESUME_JOB_DESCRIPTION_PATH, global_config.STRINGS_MODULE_NAME)
-        gpt_answerer = LLMResumeJobDescription(global_config.API_KEY, strings)
+        gpt_answerer = LLMResumeJobDescription(global_config.API_BASE_URL, global_config.API_KEY, strings)
         gpt_answerer.set_job_description_from_url(url_job_description)
         self._create_resume(gpt_answerer, style_path, temp_html_path)
 
     def create_resume_job_description_text(self, style_path: str, job_description_text: str, temp_html_path):
         strings = load_module(global_config.STRINGS_MODULE_RESUME_JOB_DESCRIPTION_PATH, global_config.STRINGS_MODULE_NAME)
-        gpt_answerer = LLMResumeJobDescription(global_config.API_KEY, strings)
+        gpt_answerer = LLMResumeJobDescription(global_config.API_BASE_URL, global_config.API_KEY, strings)
         gpt_answerer.set_job_description_from_text(job_description_text)
         self._create_resume(gpt_answerer, style_path, temp_html_path)

--- a/lib_resume_builder_AIHawk/unit-test/pdf_generation.py
+++ b/lib_resume_builder_AIHawk/unit-test/pdf_generation.py
@@ -22,6 +22,7 @@ class TestPDFGeneration(unittest.TestCase):
 
         # Extract necessary data
         self.llm_api_key = self.secrets['llm_api_key']
+        self.llm_api_url = self.config.get('llm_api_url')
         self.output_path = Path("data_folder/output")
 
         self.plain_text_resume = yaml.dump(self.plain_text_resume, default_flow_style=False)
@@ -32,7 +33,7 @@ class TestPDFGeneration(unittest.TestCase):
         print(self.plain_text_resume)
         self.resume_object = Resume(self.plain_text_resume)
         self.resume_generator_manager = FacadeManager(
-            self.llm_api_key, self.style_manager, self.resume_generator, self.resume_object, self.output_path
+            self.llm_api_key, self.style_manager, self.resume_generator, self.resume_object, self.output_path, self.llm_api_url
         )
         os.system('cls' if os.name == 'nt' else 'clear')
         # Ensure style is selected


### PR DESCRIPTION
This pull request includes using of `llm_api_url` as OpenAI base url. For example if you want to use a proxy rather than original OpenAI API, you can set this variable to use it.